### PR TITLE
Add file paths back to modal

### DIFF
--- a/src/harpoon_modal.ts
+++ b/src/harpoon_modal.ts
@@ -52,7 +52,12 @@ export default class HarpoonModal extends Modal {
 			const hookedEl = this.contentEl.createEl("div", {
 				cls: "hooked-file tree-item-self is-clickable nav-file-title",
 			});
-			
+
+			// Create container for file path
+			const pathEl = hookedEl.createEl("span", {
+				text: `${idx + 1}. ${hookedFile.path}`,
+				cls: "hooked-file-path"
+			});
 
 			// Create delete button
 			const deleteBtn = hookedEl.createEl("span", {


### PR DESCRIPTION
It looks like this was removed with the 1.0.9 release [commit](https://github.com/rodrez/obsidian-harpoon/commit/f108177ef04895196dcd73dc016f1443073cd861), so adding it back. Not sure if you intended to put it back in the `hookedEl`, but it looks better here since it goes with the styling you added.

Fixes #12 